### PR TITLE
Override callback_url to not include querystring on it

### DIFF
--- a/lib/omniauth/strategies/disqus.rb
+++ b/lib/omniauth/strategies/disqus.rb
@@ -32,6 +32,10 @@ module OmniAuth
           :raw_info => raw_info
         }
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
       
       def raw_info
         url    = '/api/3.0/users/details.json'


### PR DESCRIPTION
**What changed:**
- fix(callback): override callback_url to not include querystring on it

**Reason:**
To fix regression on omniauth-oauth2 1.4.0 that was adding the querystring on the callback url causing the provider to block the request